### PR TITLE
Fixed improper listener removal causing app crash in debug

### DIFF
--- a/lib/gif_ani.dart
+++ b/lib/gif_ani.dart
@@ -198,9 +198,10 @@ Future<List<ImageInfo>> preloadImage({
     }
   }
 
-  stream.addListener(ImageStreamListener(listener, onError: errorListener));
+  final streamListener = ImageStreamListener(listener, onError: errorListener);
+  stream.addListener(streamListener);
   completer.future.then((List<ImageInfo> _) {
-    stream.removeListener(ImageStreamListener(listener));
+    stream.removeListener(streamListener);
   });
   return completer.future;
 }


### PR DESCRIPTION
This section adds a listener and then remove it once the future is completed.

The previous code created two different objects (one with listener + onError, the second with only listener) which caused the listener to never be removed and for some reason caused the app to crash when running in debug on android.

You might want to add it to your PR on the origin repo, if it ever get accepted someday.